### PR TITLE
Remove the options to skip the TLS verification

### DIFF
--- a/controllers/pod_reconciler.go
+++ b/controllers/pod_reconciler.go
@@ -281,9 +281,7 @@ func inspectImage(ctx context.Context, clientset *kubernetes.Clientset, pod *cor
 	}
 
 	src, err := ref.NewImageSource(ctx, &types.SystemContext{
-		AuthFilePath:                authFile.Name(),
-		OCIInsecureSkipTLSVerify:    true,
-		DockerInsecureSkipTLSVerify: types.OptionalBoolTrue,
+		AuthFilePath: authFile.Name(),
 	})
 	if err != nil {
 		klog.Warningf("Error creating the image source: %v", err)


### PR DESCRIPTION
This will block untrusted registries currently. We will rely on the imageregistry configuration object to retrieve allowed/denied registries and additional CAs to consider trusted.

The internal registry is already being considered because #6 injected the cluster CA in the trusted folders the manager looks up when verifying the trusted chain.