### PR TITLE
Prepare handling of single objects, registry inspection cache and improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/controllers/core/single_obj_controller.go
+++ b/controllers/core/single_obj_controller.go
@@ -1,0 +1,94 @@
+package core
+
+import (
+	"context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"time"
+)
+
+// NewSingleObjectEventHandler creates a new event handler for a single object.
+// It exploits a WithWatch client to watch for changes on the object and execute a goroutine to listen for the channel
+// and call the handler function when an event occurs.
+// The function is generic and takes two types T and L, where T is the type of the object to watch and L is the type of
+// the list of T objects to watch. The function also takes the name of the object the handler should subscribe to
+// and the namespace to watch.
+// handler is a function that takes the event type and the object that was changed. Event types are defined in watch.go
+// and can be Added, Modified, Deleted, Bookmark and Error (not handled by handler).
+// errorHandler is an optional (nullable pointer to a) function executed when the event type is Error.
+func NewSingleObjectEventHandler[T client.Object, L client.ObjectList](ctx context.Context,
+	name string, namespace string, pollingInterval time.Duration,
+	handler func(watch.EventType, T), errorHandler *func(*metav1.Status)) error {
+
+	cfg := config.GetConfigOrDie()
+
+	cli, err := client.NewWithWatch(cfg, client.Options{})
+	if err != nil {
+		return err
+	}
+	list := reflect.New(reflect.TypeOf((*L)(nil)).Elem().Elem()).Interface().(L)
+	w, err := cli.Watch(ctx, list, &client.ListOptions{
+		Namespace: namespace,
+	})
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case e := <-w.ResultChan():
+				switch eventType := e.Type; eventType {
+				case watch.Added, watch.Modified, watch.Deleted, watch.Bookmark:
+					if e.Object != nil && e.Object.(metav1.Object).GetName() != name {
+						continue
+					}
+					handler(eventType, e.Object.DeepCopyObject().(T))
+				case watch.Error:
+					if e.Object != nil && errorHandler != nil {
+						obj := e.Object.(*metav1.Status)
+						(*errorHandler)(obj)
+					}
+				default:
+					klog.Warningf("Event type not handled: %+v", eventType)
+				}
+			}
+		}
+	}()
+
+	obj := reflect.New(reflect.TypeOf((*T)(nil)).Elem().Elem()).Interface().(T)
+	getAndHandle := func() error {
+		err := cli.Get(ctx, client.ObjectKey{
+			Namespace: namespace,
+			Name:      name,
+		}, obj)
+		if err != nil {
+			klog.Errorf("Error getting object %s/%s: %v", namespace, name, err)
+			return err
+		}
+		handler(watch.Modified, obj)
+		return nil
+	}
+	// getAndHandle is called at the end of this function to force a first synchronous get and make the
+	// lazy initialization working correctly.
+	// If we don't force the initial get, we can incur in a race condition for which the goroutine has not get and stored
+	// the globalPullSecret yet and the remote inspection tries to get it from the cache (returning nil).
+	if pollingInterval == 0 {
+		return getAndHandle()
+	}
+	// Use polling to periodically get the obj and execute the handler to guarantee robustness against the loss of watch events.
+	ticker := time.NewTicker(pollingInterval * time.Second)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				_ = getAndHandle()
+			}
+		}
+	}()
+	return getAndHandle()
+}

--- a/pkg/image/auth.go
+++ b/pkg/image/auth.go
@@ -1,0 +1,75 @@
+package image
+
+import "k8s.io/apimachinery/pkg/util/json"
+
+type authData struct {
+	Auth string `json:"auth"`
+}
+
+// authCfg struct for storing registry credentials
+type authCfg struct {
+	Auths map[string]authData `json:"auths"`
+}
+
+// addAuth takes a registry and an authData and stores it in the authCfg's Auths field
+// in case of duplicated registries, the last authData will be kept
+func (ac authCfg) addAuth(registry string, auth authData) {
+	ac.Auths[registry] = auth
+}
+
+// Currently not used
+// addAuthString takes a registry and an auth string and stores it in the authCfg's Auths field
+// in case of duplicated registries, the last generated authData will be kept
+func (ac authCfg) addAuthString(registry, auth string) {
+	ac.Auths[registry] = authData{Auth: auth}
+}
+
+// addAuths takes a map of registry:authData and stores it in the authCfg's Auths field
+// in case of duplicated registries, the last authData will be kept
+func (ac authCfg) addAuths(registryAuths map[string]authData) {
+	for registry, auth := range registryAuths {
+		ac.addAuth(registry, auth)
+	}
+}
+
+// unmarshallAuthsDataAndStore takes a byte array and unmarshalls it into a map of registry:authData
+// then, it stores the authData in the authCfg's Auths field
+// authBytes is expected to be the representation of the docker config.json's auths field.
+// The pod_reconciler will extract the imagePullSecrets field from the pod spec, get the secrets' data and store it as a [][]byte
+// each []byte is expected to be consumed as authBytes here
+// example of authsBytes:
+//
+//	{
+//	  "https://index.docker.io/v1/": {
+//	    "auth": "dXNlcm5hbWU6cGFzc3dvcmQ="
+//	  },
+//	  "https://gcr.io": {
+//	    "auth": "dXNlcm5hbWU6cGFzc3dvcmQ="
+//	  }
+//	}
+func (ac authCfg) unmarshallAuthsDataAndStore(authsBytes []byte) error {
+	var auths map[string]authData
+	if err := json.Unmarshal(authsBytes, &auths); err != nil {
+		return err
+	}
+	ac.addAuths(auths)
+	return nil
+}
+
+// marshallAuths takes the authCfg's Auths field and marshalls it into a byte array
+// the byte array is expected to be the representation of the docker config.json file
+// example of authsBytes:
+//
+//	{
+//	  "auths": {
+//	    "https://index.docker.io/v1/": {
+//	      "auth": "dXNlcm5hbWU6cGFzc3dvcmQ="
+//	    },
+//	    "https://gcr.io": {
+//	      "auth": "dXNlcm5hbWU6cGFzc3dvcmQ="
+//	    }
+//	  }
+//	}
+func (ac authCfg) marshallAuths() ([]byte, error) {
+	return json.Marshal(ac)
+}

--- a/pkg/image/cache.go
+++ b/pkg/image/cache.go
@@ -1,0 +1,36 @@
+package image
+
+import (
+	"context"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sync"
+)
+
+type cacheProxy struct {
+	registryInspector        iRegistryInspector
+	imageRefsArchitectureMap map[string]sets.Set[string]
+	mutex                    sync.Mutex
+}
+
+func (c *cacheProxy) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, secrets [][]byte) (sets.Set[string], error) {
+	if c.imageRefsArchitectureMap[imageReference] != nil {
+		return c.imageRefsArchitectureMap[imageReference], nil
+	}
+	architectures, err := c.registryInspector.GetCompatibleArchitecturesSet(ctx, imageReference, secrets)
+	if err != nil {
+		return nil, err
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.imageRefsArchitectureMap[imageReference] = architectures
+	return architectures, nil
+}
+
+func newCache() ICache {
+	return &cacheProxy{
+		imageRefsArchitectureMap: map[string]sets.Set[string]{},
+		registryInspector:        newRegistryInspector(),
+	}
+}
+
+// TODO: eviction policy

--- a/pkg/image/facade.go
+++ b/pkg/image/facade.go
@@ -1,0 +1,34 @@
+package image
+
+import (
+	"context"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sync"
+)
+
+var (
+	singletonImageFacade ICache
+	// once is used for lazy initialization of the singletonImageFacade
+	once sync.Once
+)
+
+type Facade struct {
+	inspectionCache ICache
+}
+
+func (i *Facade) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, secrets [][]byte) (architectures sets.Set[string], err error) {
+	return i.inspectionCache.GetCompatibleArchitecturesSet(ctx, imageReference, secrets)
+}
+
+func newImageFacade() ICache {
+	return &Facade{
+		inspectionCache: newCache(),
+	}
+}
+
+func FacadeSingleton() ICache {
+	once.Do(func() {
+		singletonImageFacade = newImageFacade()
+	})
+	return singletonImageFacade
+}

--- a/pkg/image/inspector.go
+++ b/pkg/image/inspector.go
@@ -1,0 +1,172 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"github.com/containers/image/v5/docker"
+	"github.com/containers/image/v5/image"
+	"github.com/containers/image/v5/manifest"
+	"github.com/containers/image/v5/types"
+	"golang.org/x/sys/unix"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2"
+	"multiarch-operator/controllers/core"
+	"os"
+	"sync"
+	"time"
+)
+
+type registryInspector struct {
+	globalPullSecret []byte
+	// mutex is used to protect the globalPullSecret field of the singletonImageFacade from concurrent write access
+	mutex sync.Mutex
+}
+
+func (i *registryInspector) GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, secrets [][]byte) (supportedArchitectures sets.Set[string], err error) {
+	// Create the auth file
+	authFile, err := i.createAuthFile(append([][]byte{i.globalPullSecret}, secrets...)...)
+	if err != nil {
+		klog.Warningf("Couldn't write auth file for: %v", err)
+		return nil, err
+	} else {
+		defer func(f *os.File) {
+			if err := f.Close(); err != nil {
+				klog.Warningf("Failed to close auth file %s %v", f.Name(), err)
+			}
+		}(authFile)
+	}
+	// Check if the image is a manifest list
+	ref, err := docker.ParseReference(imageReference)
+	if err != nil {
+		klog.Warningf("Error parsing the image reference for the image %s: %v", imageReference, err)
+		return nil, err
+	}
+	src, err := ref.NewImageSource(ctx, &types.SystemContext{
+		AuthFilePath: authFile.Name(),
+	})
+	if err != nil {
+		klog.Warningf("Error creating the image source: %v", err)
+		return nil, err
+	}
+	defer func(src types.ImageSource) {
+		err := src.Close()
+		if err != nil {
+			klog.Warningf("Error closing the image source for the image %s: %v", imageReference, err)
+		}
+	}(src)
+	rawManifest, _, err := src.GetManifest(ctx, nil)
+	if err != nil {
+		klog.Infof("Error getting the image manifest: %v", err)
+		return nil, err
+	}
+	supportedArchitectures = sets.New[string]()
+	if manifest.MIMETypeIsMultiImage(manifest.GuessMIMEType(rawManifest)) {
+		klog.V(5).Infof("image %s is a manifest list... getting the list of supported architectures",
+			imageReference)
+		// The image is a manifest list
+		index, err := manifest.OCI1IndexFromManifest(rawManifest)
+		if err != nil {
+			klog.Warningf("Error parsing the OCI index from the raw manifest of the image %s: %v",
+				imageReference, err)
+		}
+		for _, m := range index.Manifests {
+			supportedArchitectures = sets.Insert(supportedArchitectures, m.Platform.Architecture)
+		}
+		return supportedArchitectures, nil
+	} else {
+		klog.V(5).Infof("image %s is not a manifest list... getting the supported architecture", imageReference)
+		sys := &types.SystemContext{}
+		parsedImage, err := image.FromUnparsedImage(ctx, sys, image.UnparsedInstance(src, nil))
+		if err != nil {
+			klog.Warningf("Error parsing the manifest of the image %s: %v", imageReference, err)
+			return nil, err
+		}
+		config, err := parsedImage.OCIConfig(ctx)
+		if err != nil {
+			// Ignore errors due to invalid images at this stage
+			klog.Warningf("Error parsing the OCI config of the image %s: %v", imageReference, err)
+			return nil, err
+		}
+		supportedArchitectures = sets.Insert(supportedArchitectures, config.Architecture)
+	}
+	return supportedArchitectures, nil
+}
+
+func (i *registryInspector) createAuthFile(secrets ...[]byte) (*os.File, error) {
+	// Create the auth file
+	authCfgContent := &authCfg{
+		Auths: make(map[string]authData),
+	}
+	for _, secret := range secrets {
+		if err := authCfgContent.unmarshallAuthsDataAndStore(secret); err != nil {
+			klog.Warningf("Error unmarshalling pull secrets")
+			continue
+		}
+	}
+	authJson, err := authCfgContent.marshallAuths()
+	if err != nil {
+		klog.Warningf("Error marshalling pull secrets")
+		return nil, err
+	}
+	// TODO: constant-name-for-now is a placeholder. Do we need this parameter at all?
+	fd, err := writeMemFile("constant-name-for-now", authJson)
+	if err != nil {
+		return nil, err
+	}
+	// filepath to our newly created in-memory file descriptor
+	fp := fmt.Sprintf("/proc/self/fd/%d", fd)
+	return os.NewFile(uintptr(fd), fp), nil
+}
+
+// writeMemFile creates an in memory file based on memfd_create
+// returns a file descriptor. Once all references to the file are
+// dropped it is automatically released. It is up to the caller
+// to close the returned descriptor.
+func writeMemFile(name string, b []byte) (int, error) {
+	fd, err := unix.MemfdCreate(name, 0)
+	if err != nil {
+		return 0, fmt.Errorf("MemfdCreate: %v", err)
+	}
+	err = unix.Ftruncate(fd, int64(len(b)))
+	if err != nil {
+		return 0, fmt.Errorf("Ftruncate: %v", err)
+	}
+	data, err := unix.Mmap(fd, 0, len(b), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED)
+	if err != nil {
+		return 0, fmt.Errorf("Mmap: %v", err)
+	}
+	copy(data, b)
+	err = unix.Munmap(data)
+	if err != nil {
+		return 0, fmt.Errorf("Munmap: %v", err)
+	}
+	return fd, nil
+}
+
+func (i *registryInspector) storeGlobalPullSecret(pullSecret []byte) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+	i.globalPullSecret = pullSecret
+}
+
+func newRegistryInspector() iRegistryInspector {
+	ri := &registryInspector{}
+	err := core.NewSingleObjectEventHandler[*v1.Secret, *v1.SecretList](context.Background(),
+		"pull-secret", "openshift-config", time.Hour, func(et watch.EventType, cm *v1.Secret) {
+			if et == watch.Deleted || et == watch.Bookmark {
+				klog.Warningf("Ignoring event type: %+v", et)
+				return
+			}
+			klog.Warningln("global pull secret update")
+			ri.storeGlobalPullSecret(cm.Data[".dockerconfigjson"])
+		}, nil)
+	if err != nil {
+		// This is a fatal error because we cannot continue without the global pull secret controller running.
+		// We expect the kubernetes self-healing mechanism to restart the controller's pod and try recovering
+		// in case of temporary errors or initiate a CrashLoopBackOff.
+		klog.Fatalf("Error creating the event handler for the global pull secret: %v", err)
+	}
+	return ri
+}

--- a/pkg/image/interfaces.go
+++ b/pkg/image/interfaces.go
@@ -1,0 +1,20 @@
+package image
+
+import (
+	"context"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type ICache interface {
+	// GetCompatibleArchitecturesSet takes an image reference. a list of secrets and the client to the cluster and
+	// returns a set of architectures that are compatible with the image reference.
+	GetCompatibleArchitecturesSet(ctx context.Context, imageReference string, secrets [][]byte) (sets.Set[string], error)
+}
+
+type iRegistryInspector interface {
+	ICache
+	// StoreGlobalPullSecret takes a pull secret and stores it in the ImageFacade. It will be used by the controller
+	// in charge of watching the global pull secret and to store it in the ImageFacade's relevant private field.
+	// Then, the ImageFacade will be responsible for consuming it during the inspection.
+	storeGlobalPullSecret(pullSecret []byte)
+}


### PR DESCRIPTION
This PR proposes to:
1. Introduce the generic single object event handler to prepare to watch some singleton objects and configure the inspection system accordingly
2. Introduce the internal package image for registry inspection, caching, and system context configuration. We also start moving logic from the pod_reconciler to follow the separation of responsibility principle.

NewSingleObjectEventHandler creates a new event handler for a single object.
It exploits a WithWatch client to watch for changes on the object, executes a goroutine to listen for the channel, and call the handler function when an event occurs.
The function is generic and takes two types `T` and `L`, where `T` is the type of the object to watch and `L` is the type of the list of `T` objects to watch. The function also takes the name of the object the handler should subscribe to and the namespace to watch.
handler is a function that takes the event type and the changed object. Event types are defined in watch.go and can be Added, Modified, Deleted, Bookmark, and Error (not handled by the handler).
errorHandler is an optional (nullable pointer to a) function executed when the event type is Error.

~~This function is not using `L` properly yet and needs to be fixed to not use a parameter passed by the user.~~


The pkg/image package moves some logic previously implemented within the pod_reconciler by exploiting a few design patterns to improve maintainability and testability of the image caching and inspection system.
We exploit the Interface Segregation Principle by defining some small and focused interfaces by declaring only the methods required for its specific responsibility, promoting interface segregation, encapsulation, and reducing unnecessary dependencies.
The Singleton, Proxy, and Facade patterns provide a simpler interface to the more complex subsystem (ICache and its implementations). We encapsulate the complexity of the cache operations and present a unified and simplified API for clients to interact with the cache functionality.

Finally, the Facade uses lazy initialization, and some initial concurrent-safety measures are taken to protect shared resources from concurrent access.