### PR TITLE
Fix dockerconfigjson unmarshalling for the global pull secret handler

### DIFF
--- a/pkg/image/utils.go
+++ b/pkg/image/utils.go
@@ -1,0 +1,23 @@
+package image
+
+import (
+	"encoding/json"
+	"errors"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+func ExtractAuthFromSecret(secret *v1.Secret) ([]byte, error) {
+	switch secret.Type {
+	case "kubernetes.io/dockercfg":
+		return secret.Data[".dockercfg"], nil
+	case "kubernetes.io/dockerconfigjson":
+		var objmap map[string]json.RawMessage
+		if err := json.Unmarshal(secret.Data[".dockerconfigjson"], &objmap); err != nil {
+			klog.Warningf("Error unmarshaling secret data for: %s/%s", secret.Namespace, secret.Name)
+			return nil, err
+		}
+		return objmap["auths"], nil
+	}
+	return nil, errors.New("unknown secret type")
+}

--- a/test/manifests/06-example-registry-auth.yaml
+++ b/test/manifests/06-example-registry-auth.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  generateName: example-no-node-affinity-
-  namespace: test-project-1
+  generateName: example-registry-auth
   labels:
     app: httpd
   annotations:


### PR DESCRIPTION
The dockerconfigjson secret storing the global pull secret should be passed to addAuths after being unwrapped off the `auth` key. Moving the secret extraction method to a utils file in the image package temporarily to address the fix. We might want to dedicate a package to the pod manipulation soon.